### PR TITLE
feat: add optional retrycount

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Promise
 __channel__ (required): Amqplib channel. See: [connection.createChannel()](http://www.squaremobius.net/amqp.node/channel_api.html#model_createChannel)  
 __consumerQueue__ (required): Name of the queue that holds the amqp messages that need to be processed.  
 __delay__ (optional): Delay in milliseconds between retries.  Default: `Math.pow(2, <# of attempts>)`  
-__retryCount__ (optional): The amount of retries before failing the message.   
 __failureQueue__ (optional):  Name of the queue that holds the amqp messages that could not be processed in spite of the retries.  Default: `<consumerQueue>.failure`  
 __handler__ (required): Set up a consumer with a callback to be invoked with each message.  
 

--- a/src/amqp_handler_wrapper.js
+++ b/src/amqp_handler_wrapper.js
@@ -12,7 +12,7 @@ const getDefaultDelay = (attempts) => {
   return delay * 1000
 }
 
-module.exports = function (channel, clientQueueName, failureQueueName, clientHandler, delayFunction, retryCount, initializer) {
+module.exports = function (channel, clientQueueName, failureQueueName, clientHandler, delayFunction, initializer) {
   const errorHandler = (msg) => {
     if (!initializer.isInitialized) {
       // Delay in 1 MS to let the queues/exchange/bindings initialize
@@ -24,10 +24,6 @@ module.exports = function (channel, clientQueueName, failureQueueName, clientHan
     _.defaults(msg, { properties: {} })
     _.defaults(msg.properties, { headers: {} })
     _.defaults(msg.properties.headers, { _retryCount: 0 }) // _retryCount: 0 means this message has never been retried before.
-
-    if(!isNaN(retryCount) && retryCount >= msg.properties.headers._retryCount){
-      return channel.sendToQueue(failureQueueName, new Buffer(msg.content), msg.properties)
-    }
 
     msg.properties.headers._retryCount += 1
     const expiration = (delayFunction || getDefaultDelay)(msg.properties.headers._retryCount)

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ module.exports = (options) => {
   // initializing the objects
   const initializer = new Initializer(options.channel, options.consumerQueue, options.failureQueue)
   const consumer = new ReadyQueueConsumer(options.channel)
-  const wrapper = amqpHandlerWrapper(options.channel, options.consumerQueue, options.failureQueue, options.handler, options.delay, options.retryCount, initializer)
+  const wrapper = amqpHandlerWrapper(options.channel, options.consumerQueue, options.failureQueue, options.handler, options.delay, initializer)
 
   // initializing the queues, exchange and binding. Then starting the consumer
   initializer


### PR DESCRIPTION
Instead of only relying on the 24 hour timeout, add an option to set the amount of retries before the message is dropped.